### PR TITLE
CrateDB: Make "CREATE SCHEMA" a no-op

### DIFF
--- a/mage_ai/io/postgres.py
+++ b/mage_ai/io/postgres.py
@@ -166,6 +166,8 @@ class Postgres(BaseSQL):
         self,
         schema_name: str
     ) -> str:
+        # FIXME: Make this a no-op only for CrateDB.
+        return "SELECT 1;"
         return f"""
         DO $$
         BEGIN


### PR DESCRIPTION
## About
Probably the quickest and smallest patch to resolve an error when connecting to CrateDB. Thanks again, @proddata.

```python
InternalError_: line 1:8: no viable alternative at input 'CREATE SCHEMA'
```

## References
- GH-1
- https://github.com/crate/crate/issues/14601

## Backlog
Needs to be reworked to be provided on behalf of a dedicated dialect, instead of hacking the PostgreSQL adapter. Can be provided by a subsequent patch, the main goal is to get this going.
